### PR TITLE
Fixing extract() exploit on Questions functionality

### DIFF
--- a/Questions.php
+++ b/Questions.php
@@ -1,9 +1,9 @@
 <?php session_start();
 require_once('connection.php');
 require_once('sessionSet.php');
-extract($_POST);
-extract($_GET);
-extract($_SESSION);
+// extract($_POST);
+// extract($_GET);
+// extract($_SESSION);
 ?>
 <!--/ PHP Code: Token Entery -->
 <!DOCTYPE html>

--- a/sessionSet.php
+++ b/sessionSet.php
@@ -3,11 +3,13 @@ require_once('connection.php');
 
 if(!isset($_SESSION['Email']))
 {
-	?>
-    <script>
-        window.location = "Login.php";
-    </script>
-    <?php
+	// 
+    // <script>
+    //     window.location = "Login.php";
+    // </script>
+    // 
+    header("location:Login.php");
+    exit();
 }
 
 ?>


### PR DESCRIPTION
Hello. I was searching repositories that have this kind of exploit to fix. The extract function should never be used on $_GET or $_POST because it can overwrite variables on your application (even $_SESSION variables) and be used as an exploit to hack someone's account or give privileges that has never given to an user (for example, by overwrite $role variable).